### PR TITLE
Add New Source File Extensions to INF Syntax

### DIFF
--- a/syntaxes/edk2_inf.tmLanguage.json
+++ b/syntaxes/edk2_inf.tmLanguage.json
@@ -19,7 +19,7 @@
 				},
 				{
 					"name": "variable.parameter.edk2_inf",
-					"match": "[\\w/-]+\\.(dec|c|uni|h|vfr|Vfr|hfr|asm|nasm|S)"
+					"match": "[\\w/-]+\\.(dec|c|uni|h|vfr|Vfr|hfr|asm|nasm|S|asl|aslc)"
 				},
 				{
 					"name": "constant.numeric.edk2_inf",

--- a/syntaxes/edk2_inf.tmLanguage.json
+++ b/syntaxes/edk2_inf.tmLanguage.json
@@ -19,7 +19,7 @@
 				},
 				{
 					"name": "variable.parameter.edk2_inf",
-					"match": "[\\w/-]+\\.(dec|c|uni|h|vfr|Vfr|hfr)"
+					"match": "[\\w/-]+\\.(dec|c|uni|h|vfr|Vfr|hfr|asm|nasm|S)"
 				},
 				{
 					"name": "constant.numeric.edk2_inf",


### PR DESCRIPTION
This PR adds the following source file extensions  to the INF syntax rules:
* .asm (typically used for Microsoft Assembler)
* .nasm (typically used for Netwide Assembler)
* .S (typically used for GNU Assembler)
* .asl (typically used for ACPI Source Language)
* .aslc (typically used for C source files related to ACPI)

These assembly file extensions are commonly used for source files in many modules. The BaseLib INF provides an example in the edk2 repository that uses all three extensions as source files - https://github.com/tianocore/edk2/blob/master/MdePkg/Library/BaseLib/BaseLib.inf.

An INF file example that includes both .asl and .aslc files can be found here - https://github.com/tianocore/edk2/blob/master/OvmfPkg/AcpiTables/AcpiTables.inf. Though these file types are even more common in platform repositories that contain ASL code for a particular system.