### PR TITLE
Support *.dsc.inc and *.fdf.inc

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
       {
         "id": "edk2_dsc",
         "extensions": [
-          ".dsc"
+          ".dsc",
+          ".dsc.inc"
         ],
         "configuration": "./confs/edk2_dsc.conf.json"
       },
@@ -38,7 +39,8 @@
       {
         "id": "edk2_fdf",
         "extensions": [
-          ".fdf"
+          ".fdf",
+          ".fdf.inc"
         ],
         "configuration": "./confs/edk2_fdf.conf.json"
       },


### PR DESCRIPTION
We got many feedback for *.inc support. For edk2 world, that's a convention so now I decide to add this in default syntax highlight.
https://github.com/WalonLi/edk2-vscode/issues/17
https://github.com/WalonLi/edk2-vscode/issues/11
https://github.com/WalonLi/edk2-vscode/issues/8