### PR TITLE
Fix GitLens CodeLens blame on every line in EDK2 files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -362,8 +362,8 @@ class Edk2DscSymbolProvider implements vscode.DocumentSymbolProvider {
 
     let keywords = new Map <string, vscode.SymbolKind>([
       ['Pcd', vscode.SymbolKind.Variable],
-      ['Component', vscode.SymbolKind.File],
-      ['Library', vscode.SymbolKind.Package]
+      ['Component', vscode.SymbolKind.Field],
+      ['Library', vscode.SymbolKind.Constant]
     ]);
 
     return new Promise((resolve, reject) => {
@@ -432,10 +432,10 @@ class Edk2DecSymbolProvider implements vscode.DocumentSymbolProvider {
 
     let keywords = new Map <string, vscode.SymbolKind>([
       ['Pcd', vscode.SymbolKind.Variable],
-      ['Library', vscode.SymbolKind.Package],
-      ['Guids', vscode.SymbolKind.Interface],
-      ['Ppis', vscode.SymbolKind.Interface],
-      ['Protocols', vscode.SymbolKind.Interface],
+      ['Library', vscode.SymbolKind.Constant],
+      ['Guids', vscode.SymbolKind.EnumMember],
+      ['Ppis', vscode.SymbolKind.EnumMember],
+      ['Protocols', vscode.SymbolKind.EnumMember],
     ]);
 
     return new Promise((resolve, reject) => {
@@ -551,13 +551,13 @@ class Edk2InfSymbolProvider implements vscode.DocumentSymbolProvider {
   public provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.DocumentSymbol[]> {
 
     let keywords = new Map <string, vscode.SymbolKind>([
-      ['Sources', vscode.SymbolKind.File],
-      ['Packages', vscode.SymbolKind.File],
+      ['Sources', vscode.SymbolKind.Field],
+      ['Packages', vscode.SymbolKind.Field],
       ['Pcd', vscode.SymbolKind.Variable],
-      ['Library', vscode.SymbolKind.Package],
-      ['Protocol', vscode.SymbolKind.Interface],
-      ['Ppi', vscode.SymbolKind.Interface],
-      ['Guid', vscode.SymbolKind.Interface],
+      ['Library', vscode.SymbolKind.Constant],
+      ['Protocol', vscode.SymbolKind.EnumMember],
+      ['Ppi', vscode.SymbolKind.EnumMember],
+      ['Guid', vscode.SymbolKind.EnumMember],
       ['Depex', vscode.SymbolKind.Operator],
     ]);
 


### PR DESCRIPTION
## Summary

Replace only the child symbol kinds that fall in GitLens' default `"containers"` CodeLens scope with semantically appropriate alternatives that don't trigger blame annotations:

| Category | Before (containers scope) | After (default scope) |
|----------|--------------------------|----------------------|
| Sources / Components | `File` | `Field` |
| Libraries | `Package` | `Constant` |
| Guids / Ppis / Protocols | `Interface` | `EnumMember` |
| PCDs | `Variable` | `Variable` (unchanged) |
| Depex | `Operator` | `Operator` (unchanged) |

Section headers remain as `SymbolKind.Class`. Outline panel and breadcrumbs preserved with distinct icons per category.

## Root Cause

GitLens places CodeLens blame on symbols in the `"containers"` scope (`File`, `Package`, `Interface`, etc.), which is [enabled by default](https://github.com/gitkraken/vscode-gitlens/blob/main/src/codelens/codeLensProvider.ts). The original symbol providers used these kinds for every child entry, causing blame on nearly every line.

`Variable`, `Operator`, `Field`, `Constant`, and `EnumMember` all fall in GitLens' `default` switch case — they only receive CodeLens if explicitly configured by the user.

Fixes #6